### PR TITLE
Fix summary.r-squared property reference

### DIFF
--- a/Results scoring.Rmd
+++ b/Results scoring.Rmd
@@ -544,6 +544,6 @@ plot_model(lm_model, type = "eff", terms = c("chartjunk", "hierarchy"))
 plot_model(lm_model, type = "eff", terms = c("hierarchy"))
 ```
 ```{r}
-summary.lm(anova_model)$r.squared5
+summary.lm(anova_model)$r.squared
 ```
 


### PR DESCRIPTION
## Summary
- Corrected use of `summary.lm` in `Results scoring.Rmd` to reference the proper `r.squared` field instead of the invalid `r.squared5`.

## Testing
- `Rscript -e 'summary(lm(mpg ~ wt, data = mtcars))$r.squared'`


------
https://chatgpt.com/codex/tasks/task_e_68979cf357248331a1091527f9cf8979